### PR TITLE
Fix go redirect

### DIFF
--- a/server/routes/go/[slug].get.ts
+++ b/server/routes/go/[slug].get.ts
@@ -1,6 +1,6 @@
 import { getHeader } from "h3"
-import { getCloudflareEnv, getCloudflareRequestInfo, getKVNamespace } from "~/server/utils/cloudflare"
-import { updateRedirectMetrics, updateRedirectMetricsAsync } from "~/server/utils/kv-metrics"
+import { getCloudflareEnv, getKVNamespace } from "~/server/utils/cloudflare"
+import { updateRedirectMetricsAsync } from "~/server/utils/kv-metrics"
 import { createApiError, createApiResponse, isApiError, logRequest } from "~/server/utils/response"
 import { UrlRedirectSchema } from "~/server/utils/schemas"
 
@@ -74,7 +74,7 @@ export default defineEventHandler(async (event) => {
       cached: "hit"
     })
 
-    // Perform redirect using createApiResponse with redirect parameter
+    // Perform redirect using standard API response
     return createApiResponse({
       result: {
         redirect: redirect.url,
@@ -82,8 +82,10 @@ export default defineEventHandler(async (event) => {
         clicks: redirect.clicks + 1
       },
       message: `Redirecting to ${redirect.url}`,
-      error: null,
-      redirect: redirect.url
+      redirect: redirect.url,
+      event,
+      code: 302,
+      error: null
     })
   } catch (error: unknown) {
     // biome-ignore lint/suspicious/noExplicitAny: isApiError type guard ensures statusCode property exists


### PR DESCRIPTION
## Summary
- add event option for redirects in `createApiResponse`
- use new redirect option in go route

## Testing
- `bun run build`
- `bun run lint:biome`
- `bun run lint:trunk` *(fails: fetch failed)*
- `bun run lint:types` *(fails: Property 'CLOUDFLARE_API_TOKEN' does not exist on type 'Env')*
- `bun run test`
- `bun run check` *(fails: network errors during package install)*

------
https://chatgpt.com/codex/tasks/task_e_684ddcd729248332b92eb088a7f4b2e1

## Summary by Sourcery

Improve redirect handling by extending the API response utility with an `event` option for H3 redirection, updating the go route to supply the event and status code, and retaining a fallback for legacy cases.

Bug Fixes:
- Fix go route HTTP redirect handling to correctly trigger H3’s sendRedirect

Enhancements:
- Add an optional `event` parameter to `createApiResponse` to enable direct use of H3’s `sendRedirect`
- Introduce a fallback error throw for legacy redirect callers when `event` is not provided
- Update the go route handler to pass `event` and HTTP status code into `createApiResponse` for proper redirection