### PR TITLE
Fix metricsData schema compliance

### DIFF
--- a/server/api/token/[uuid]/[...path].get.ts
+++ b/server/api/token/[uuid]/[...path].get.ts
@@ -145,10 +145,11 @@ export default defineEventHandler(async (event) => {
       ])
 
       const metricsData = {
-        total_requests: totalRequests,
-        successful_requests: successfulRequests,
-        failed_requests: failedRequests,
-        redirect_clicks: 0
+        uuid,
+        totalRequests,
+        successfulRequests,
+        failedRequests,
+        createdAt: createdAtStr
       }
 
       // Record successful metrics


### PR DESCRIPTION
Fix `/api/token/{uuid}/metrics` endpoint to return `metricsData` conforming to `TokenMetricsDataSchema`.

Previously, the `metricsData` object used `snake_case` field names, was missing required `uuid` and `createdAt` fields, and included an unneeded `redirect_clicks` field, leading to runtime validation failures.

## Summary by Sourcery

Fix metricsData schema compliance by updating the returned object to match TokenMetricsDataSchema

Bug Fixes:
- Use camelCase field names for totalRequests, successfulRequests, and failedRequests
- Add required uuid and createdAt fields to metricsData
- Remove redundant redirect_clicks field from the response