### PR TITLE
✨ Add latest page tracking functionality with Pinia store

### DIFF
--- a/app/plugins/latest-page.client.ts
+++ b/app/plugins/latest-page.client.ts
@@ -1,0 +1,20 @@
+import type { RouteLocationNormalized, RouteLocationNormalizedLoaded, Router } from "vue-router"
+import { useLatestPageStore } from "~~/stores/latest-page"
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const router = nuxtApp.$router as Router | undefined
+  if (!router) {
+    return
+  }
+
+  const latestPageStore = useLatestPageStore()
+  const initialRoute: RouteLocationNormalizedLoaded | undefined = router.currentRoute.value
+
+  if (initialRoute) {
+    latestPageStore.setLatestPath(initialRoute.fullPath)
+  }
+
+  router.afterEach((to: RouteLocationNormalized) => {
+    latestPageStore.setLatestPath(to.fullPath)
+  })
+})

--- a/stores/latest-page.ts
+++ b/stores/latest-page.ts
@@ -1,0 +1,16 @@
+import { ref } from "vue"
+import { defineStore } from "pinia"
+
+// Tracks the most recently visited route for use across the app.
+export const useLatestPageStore = defineStore("latestPage", () => {
+  const latestPath = ref<string | null>(null)
+
+  const setLatestPath = (path: string) => {
+    latestPath.value = path
+  }
+
+  return {
+    latestPath,
+    setLatestPath,
+  }
+})


### PR DESCRIPTION
Implements a client-side plugin and Pinia store to track the most
recently visited route. The plugin automatically updates the store
on route changes, enabling the application to remember and reference
the user's last visited page across different components.

## Summary by Sourcery

Add functionality to track the user’s most recently visited route via a Pinia store and Nuxt client plugin

New Features:
- Introduce a Pinia store to hold and update the latest visited page path
- Implement a Nuxt client plugin that initializes and updates the latest-page store on route changes