### PR TITLE
fix: remove redundant colour config, add a logger hook to pages/index.vue

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -9,12 +9,6 @@
 </template>
 
 <script setup lang="ts">
-// Set default color mode preference
-const colorMode = useColorMode()
-if (import.meta.client) {
-  colorMode.preference = "dark"
-}
-
 const route = useRoute()
 const layoutProps = computed(() => route.meta.layoutProps ?? {})
 </script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -221,6 +221,6 @@ definePageMeta({
 })
 
 onMounted(() => {
-  // Page mounted
+  logger.info("pages/index.vue mounted")
 })
 </script>


### PR DESCRIPTION
## Summary by Sourcery

Clean up obsolete default color mode preference code and introduce logging on page mount in pages/index.vue

Enhancements:
- Remove redundant color mode configuration from app/app.vue
- Add logger.info call to onMounted hook in pages/index.vue